### PR TITLE
Fixed potential snapshot issue and added recovery for devices missing…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,6 @@ coverage
 /headless/
 
 # Local memory for AI agents
+AGENTS.md
 memory.md
 docs/bootstrap-v3-analysis.md

--- a/ndn/app/workspace.go
+++ b/ndn/app/workspace.go
@@ -29,8 +29,14 @@ import (
 	"github.com/pulsejet/ownly/ndn/app/tlv"
 )
 
-// TODO: find optimal value
-const SnapshotThreshold = 100
+const (
+	// TODO: find optimal value
+	SnapshotThreshold = 100
+
+	// Bound missing-key recovery so a peer cannot retain publications forever.
+	maxPendingDecryptPubs = 256
+	maxPendingDecryptAge  = 10 * time.Minute
+)
 
 // TODO: change this
 var repoName, _ = enc.NameFromStr("/ndnd/ucla/repo3")
@@ -1275,12 +1281,24 @@ func (a *App) SvsAloJs(
 
 	// Wrap the SVS ALO instance in a JS API
 	var svsAloJs map[string]any
+	var retryPendingDecryptPubs func()
+	started := false
+	stopped := false
+	routesAnnounced := false
 	svsAloJs = map[string]any{
-		"sync_prefix": js.ValueOf(alo.SyncPrefix().String()),
-		"data_prefix": js.ValueOf(alo.DataPrefix().String()),
+		"sync_prefix":         js.ValueOf(alo.SyncPrefix().String()),
+		"data_prefix":         js.ValueOf(alo.DataPrefix().String()),
+		"safe_stop_unstarted": js.ValueOf(true),
 
 		// start(): Promise<void>;
 		"start": jsutil.AsyncFunc(func(this js.Value, p []js.Value) (any, error) {
+			if stopped {
+				return nil, fmt.Errorf("SVS instance has been stopped")
+			}
+			if started {
+				return nil, nil
+			}
+
 			// Announce prefixes to the network
 			for _, route := range routes {
 				client.AnnouncePrefix(ndn.Announcement{
@@ -1290,31 +1308,50 @@ func (a *App) SvsAloJs(
 				})
 				log.Info(nil, "Announcing prefix", "name", "prefix", route)
 			}
+			routesAnnounced = true
+
+			if err := alo.Start(); err != nil {
+				for _, route := range routes {
+					client.WithdrawPrefix(route, nil)
+				}
+				routesAnnounced = false
+				return nil, err
+			}
+			started = true
 
 			// Notify repo to start
 			a.ExecWithConnectivity(func() {
 				a.NotifyRepoJoin(client, alo.GroupPrefix(), alo.DataPrefix(), true)
 			})
 
-			if err := alo.Start(); err != nil {
-				return nil, err
-			}
-
 			return nil, nil
 		}),
 
 		// stop(): Promise<void>;
 		"stop": jsutil.AsyncFunc(func(this js.Value, p []js.Value) (any, error) {
-			if err := alo.Stop(); err != nil {
-				return nil, err
+			if stopped {
+				return nil, nil
 			}
+			stopped = true
 
-			for _, route := range routes {
-				client.WithdrawPrefix(route, nil)
+			var stopErr error
+			if started {
+				stopErr = alo.Stop()
+				started = false
+			}
+			// A publisher callback may already be unwinding when Stop returns.
+			// Leave it a safe callable target instead of replacing it with nil.
+			retryPendingDecryptPubs = func() {}
+
+			if routesAnnounced {
+				for _, route := range routes {
+					client.WithdrawPrefix(route, nil)
+				}
+				routesAnnounced = false
 			}
 
 			jsutil.ReleaseMap(svsAloJs)
-			return nil, nil
+			return nil, stopErr
 		}),
 
 		// set_on_error(): void;
@@ -1579,6 +1616,16 @@ func (a *App) SvsAloJs(
 			return js.ValueOf(name.String()), nil
 		}),
 
+		// retry_pending_decrypts(): Promise<void>;
+		"retry_pending_decrypts": jsutil.AsyncFunc(func(this js.Value, p []js.Value) (any, error) {
+			// MLS state can be restored outside an SVS receive callback, so callers
+			// need an explicit way to retry publications unlocked by that state.
+			if retryPendingDecryptPubs != nil {
+				retryPendingDecryptPubs()
+			}
+			return nil, nil
+		}),
+
 		// subscribe({
 		//   on_yjs_delta,
 		//   on_mls_kp_ref,
@@ -1588,8 +1635,73 @@ func (a *App) SvsAloJs(
 		//   on_refresh_pong,
 		// }): Promise<void>;
 		"subscribe": jsutil.AsyncFunc(func(this js.Value, p []js.Value) (any, error) {
+			type pendingDecryptPub struct {
+				pub       ndn_sync.SvsPub
+				sessionID string
+				queuedAt  time.Time
+			}
+
+			pendingDecryptPubs := make([]pendingDecryptPub, 0)
+			// Index exact publications for deduplication and streams for ordering.
+			pendingDecryptKeys := make(map[string]struct{})
+			pendingDecryptStreams := make(map[string]int)
+			var deferredSvsState []byte
+
+			// Boot time distinguishes separate runs of the same publisher.
+			pendingPubKey := func(pub ndn_sync.SvsPub) string {
+				return fmt.Sprintf("%s\x00%d\x00%d", pub.Publisher.String(), pub.BootTime, pub.SeqNum)
+			}
+			pendingStreamKey := func(pub ndn_sync.SvsPub) string {
+				return fmt.Sprintf("%s\x00%d", pub.Publisher.String(), pub.BootTime)
+			}
+			rebuildPendingDecryptIndex := func() {
+				pendingDecryptKeys = make(map[string]struct{}, len(pendingDecryptPubs))
+				pendingDecryptStreams = make(map[string]int)
+				for _, pending := range pendingDecryptPubs {
+					pendingDecryptKeys[pendingPubKey(pending.pub)] = struct{}{}
+					pendingDecryptStreams[pendingStreamKey(pending.pub)]++
+				}
+			}
+			prunePendingDecryptPubs := func(now time.Time) {
+				// Filter in place and clear discarded entries so their content buffers
+				// are not retained by the queue's backing array.
+				kept := pendingDecryptPubs[:0]
+				for _, pending := range pendingDecryptPubs {
+					if now.Sub(pending.queuedAt) <= maxPendingDecryptAge {
+						kept = append(kept, pending)
+					}
+				}
+				clear(pendingDecryptPubs[len(kept):])
+				pendingDecryptPubs = kept
+				rebuildPendingDecryptIndex()
+			}
+			queuePendingDecryptPub := func(pub ndn_sync.SvsPub, sessionID string) {
+				now := time.Now()
+				prunePendingDecryptPubs(now)
+
+				key := pendingPubKey(pub)
+				if _, exists := pendingDecryptKeys[key]; exists {
+					return
+				}
+
+				// Drop the oldest publication when the retry queue is full.
+				if len(pendingDecryptPubs) >= maxPendingDecryptPubs {
+					pendingDecryptPubs[0] = pendingDecryptPub{}
+					pendingDecryptPubs = pendingDecryptPubs[1:]
+					rebuildPendingDecryptIndex()
+				}
+
+				pendingDecryptPubs = append(pendingDecryptPubs, pendingDecryptPub{
+					pub:       pub,
+					sessionID: sessionID,
+					queuedAt:  now,
+				})
+				pendingDecryptKeys[key] = struct{}{}
+				pendingDecryptStreams[pendingStreamKey(pub)]++
+			}
+
 			// Send a list of publications to the JS callback
-			sendPub := func(pubs []ndn_sync.SvsPub) {
+			sendPub := func(pubs []ndn_sync.SvsPub, enforcePendingOrder bool) {
 				yjsDeltas := js.Global().Get("Array").New()
 				mlsKpRefs := js.Global().Get("Array").New()
 				mlsWelcomeRefs := js.Global().Get("Array").New()
@@ -1602,6 +1714,18 @@ func (a *App) SvsAloJs(
 					if err != nil {
 						log.Error(nil, "Failed to parse publication", "err", err)
 						continue
+					}
+
+					if pmsg.AeadBlock != nil {
+						// Queue only missing-key ciphertext. If this publisher already
+						// has a pending entry, queue later ciphertext as well so sequence
+						// numbers cannot overtake the blocked publication.
+						sessionID := pmsg.AeadBlock.SessionID
+						streamBlocked := enforcePendingOrder && pendingDecryptStreams[pendingStreamKey(pub)] > 0
+						if streamBlocked || a.cipherForSession(sessionID) == nil {
+							queuePendingDecryptPub(pub, sessionID)
+							continue
+						}
 					}
 
 					pmsg, err = a.decryptPub(pmsg)
@@ -1743,30 +1867,92 @@ func (a *App) SvsAloJs(
 				invokeBatch("on_refresh_pong", refreshPongs)
 			}
 
+			// Retry the decryptable prefix of each publisher boot stream. A missing
+			// earlier key keeps later entries in that stream queued.
+			retryPendingDecryptPubs = func() {
+				prunePendingDecryptPubs(time.Now())
+				if len(pendingDecryptPubs) == 0 {
+					if deferredSvsState != nil {
+						jsutil.Await(persistState.Invoke(jsutil.SliceToJsArray(deferredSvsState)))
+						deferredSvsState = nil
+					}
+					return
+				}
+
+				ready := make([]ndn_sync.SvsPub, 0, len(pendingDecryptPubs))
+				remaining := make([]pendingDecryptPub, 0, len(pendingDecryptPubs))
+				blockedStreams := make(map[string]bool)
+				for _, pending := range pendingDecryptPubs {
+					streamKey := pendingStreamKey(pending.pub)
+					if blockedStreams[streamKey] || a.cipherForSession(pending.sessionID) == nil {
+						blockedStreams[streamKey] = true
+						remaining = append(remaining, pending)
+						continue
+					}
+					ready = append(ready, pending.pub)
+				}
+
+				pendingDecryptPubs = remaining
+				rebuildPendingDecryptIndex()
+				if len(ready) > 0 {
+					sendPub(ready, false)
+				}
+				if len(pendingDecryptPubs) == 0 && deferredSvsState != nil {
+					jsutil.Await(persistState.Invoke(jsutil.SliceToJsArray(deferredSvsState)))
+					deferredSvsState = nil
+				}
+			}
+
 			// Subscribe to the SVS instance
 			alo.SubscribePublisher(enc.Name{}, func(pub ndn_sync.SvsPub) {
+				retryPendingDecryptPubs()
+
 				if !pub.IsSnapshot {
-					sendPub([]ndn_sync.SvsPub{pub})
+					sendPub([]ndn_sync.SvsPub{pub}, true)
 				} else {
 					snapshot, err := svs_ps.ParseHistorySnap(enc.NewWireView(pub.Content), true)
 					if err != nil {
 						panic(err) // we encode this, so this never happens
 					}
 
-					pubs := make([]ndn_sync.SvsPub, 0, len(snapshot.Entries))
+					// MLS key transitions are published in plaintext. Process them before
+					// encrypted snapshot entries so their callbacks can install any session
+					// keys needed by the rest of this snapshot.
+					mlsTransitionPubs := make([]ndn_sync.SvsPub, 0)
+					otherPubs := make([]ndn_sync.SvsPub, 0, len(snapshot.Entries))
 					for _, entry := range snapshot.Entries {
-						pubs = append(pubs, ndn_sync.SvsPub{
+						snapshotPub := ndn_sync.SvsPub{
 							Publisher: pub.Publisher,
 							Content:   entry.Content,
 							BootTime:  pub.BootTime,
 							SeqNum:    entry.SeqNo,
-						})
-					}
-					sendPub(pubs)
-				}
+						}
 
-				// Persist state
-				jsutil.Await(persistState.Invoke(jsutil.SliceToJsArray(pub.State.Join())))
+						msg, parseErr := tlv.ParseMessage(enc.NewWireView(entry.Content), true)
+						if parseErr == nil && (msg.MlsWelcome != nil || msg.MlsCommit != nil) {
+							mlsTransitionPubs = append(mlsTransitionPubs, snapshotPub)
+						} else {
+							otherPubs = append(otherPubs, snapshotPub)
+						}
+					}
+
+					sendPub(mlsTransitionPubs, true)
+					retryPendingDecryptPubs()
+					sendPub(otherPubs, true)
+				}
+				retryPendingDecryptPubs()
+
+				// Keep the previously persisted SVS cursor while encrypted publications
+				// are pending. A restart can then fetch them again if the in-memory queue
+				// does not get a chance to drain.
+				if len(pendingDecryptPubs) == 0 {
+					jsutil.Await(persistState.Invoke(jsutil.SliceToJsArray(pub.State.Join())))
+					deferredSvsState = nil
+				} else {
+					// Save the newest cursor in memory, but do not commit it while data
+					// remains queued. A restart will then refetch the unresolved range.
+					deferredSvsState = append(deferredSvsState[:0], pub.State.Join()...)
+				}
 
 				return
 			})

--- a/src/services/ndn.ts
+++ b/src/services/ndn.ts
@@ -173,6 +173,8 @@ export interface SvsAloApi {
   sync_prefix: string;
   /** Data prefix of the instance */
   data_prefix: string;
+  /** Whether stop() is safe before start() has completed */
+  safe_stop_unstarted?: boolean;
 
   /** Start the SVS instance */
   start(): Promise<void>;
@@ -202,6 +204,8 @@ export interface SvsAloApi {
   pub_mls_welcome_ref(invitee: string, blobName: string, sessionId: string): Promise<string>;
   /** Publish MLS commit message for a group change */
   pub_mls_commit_ref(invitee: string, blobName: string, sessionId: string): Promise<string>;
+  /** Retry encrypted publications that were waiting for an MLS session key */
+  retry_pending_decrypts?(): Promise<void>;
 
   /** Set SVS ALO subscription callbacks */
   subscribe(params: {

--- a/src/services/svs-provider.ts
+++ b/src/services/svs-provider.ts
@@ -30,6 +30,11 @@ export class SvsProvider {
   private pendingMlsKpRefs: MlsRefPub[] = [];
   private pendingMlsWelcomeRefs: MlsRefPub[] = [];
   private pendingMlsCommitRefs: MlsRefPub[] = [];
+  private mlsDispatchTail: Promise<void> = Promise.resolve();
+  private subscribed = false;
+  private started = false;
+  private destroyed = false;
+  private startPromise: Promise<void> | null = null;
 
   private readonly refreshPingSubs = new Set<SvsAloSub<RefreshPingPub>>();
   private readonly refreshPongSubs = new Set<SvsAloSub<RefreshPongPub>>();
@@ -41,16 +46,31 @@ export class SvsProvider {
   ) {}
 
   public setMlsCallbacks(cb: {
-  onMlsKpRef?: MlsRefHandler;
-  onMlsWelcomeRef?: MlsRefHandler;
-  onMlsCommitRef?: MlsRefHandler;
+    onMlsKpRef?: MlsRefHandler;
+    onMlsWelcomeRef?: MlsRefHandler;
+    onMlsCommitRef?: MlsRefHandler;
   }) {
     if (cb.onMlsKpRef) this.onMlsKpRef = cb.onMlsKpRef;
     if (cb.onMlsWelcomeRef) this.onMlsWelcomeRef = cb.onMlsWelcomeRef;
     if (cb.onMlsCommitRef) this.onMlsCommitRef = cb.onMlsCommitRef;
+  }
 
+  /**
+   * Deliver MLS references buffered during startup. Call this only after the
+   * consumer has restored its persisted MLS state.
+   */
+  public async activateMlsCallbacks(): Promise<void> {
+    if (this.mlsCallbacksReady) return;
     this.mlsCallbacksReady = true;
-    void this.flushPendingMlsRefs();
+    await this.enqueueMlsDispatch(async () => this.flushPendingMlsRefs());
+  }
+
+  private enqueueMlsDispatch(task: () => Promise<void>): Promise<void> {
+    const run = this.mlsDispatchTail.then(task, task);
+    // Keep one rejected callback from preventing later MLS publications from
+    // being handled, while still returning the error to the current caller.
+    this.mlsDispatchTail = run.catch(() => {});
+    return run;
   }
 
   private async flushPendingMlsRefs() {
@@ -61,6 +81,9 @@ export class SvsProvider {
     if (kp.length) await this.onMlsKpRef(kp);
     if (w.length) await this.onMlsWelcomeRef(w);
     if (c.length) await this.onMlsCommitRef(c);
+    // Buffered MLS callbacks run after the original Go receive callback, so
+    // explicitly retry any publications their newly installed keys unlocked.
+    await this.svs.retry_pending_decrypts?.();
   }
 
   /**
@@ -70,12 +93,22 @@ export class SvsProvider {
    * @param project Project name
    */
   public static async create(wksp: WorkspaceAPI, project: string): Promise<SvsProvider> {
+    const provider = await SvsProvider.createPaused(wksp, project);
+    try {
+      await provider.start();
+      return provider;
+    } catch (e) {
+      // Preserve the startup error; cleanup is best effort because a partially
+      // constructed provider is never returned to the caller.
+      await provider.destroy().catch(() => {});
+      throw e;
+    }
+  }
+
+  /** Create a provider whose local database is ready but whose SVS loop is paused. */
+  public static async createPaused(wksp: WorkspaceAPI, project: string): Promise<SvsProvider> {
     const { db, svs } = await SvsProvider.createComponents(wksp, project);
-
-    const provider = new SvsProvider(db, wksp, svs);
-    await provider.start();
-
-    return provider;
+    return new SvsProvider(db, wksp, svs);
   }
 
   /**
@@ -112,25 +145,52 @@ export class SvsProvider {
    * This will stop the SVS instance and clean up all documents.
    */
   public async destroy() {
-    for (const doc of this.docs.values()) {
-      doc.destroy();
+    if (this.destroyed) return;
+    this.destroyed = true;
+
+    // If destruction races startup, wait until start settles before stopping
+    // the Go wrapper and closing its database.
+    await this.startPromise?.catch(() => {});
+
+    try {
+      // Older checked-in WASM builds block if stop() is called before start().
+      // Newer wrappers advertise that they can safely release an unstarted ALO.
+      if (this.started || this.svs.safe_stop_unstarted) {
+        await this.svs.stop();
+      }
+    } finally {
+      this.started = false;
+      // Stop network delivery before releasing objects used by its callbacks.
+      for (const doc of this.docs.values()) {
+        doc.destroy();
+      }
+      for (const bundler of this.bundlers.values()) {
+        bundler.dispose();
+      }
+      this.docs.clear();
+      this.bundlers.clear();
+      this.aware.clear();
+      await this.db.close();
     }
-    for (const bundler of this.bundlers.values()) {
-      bundler.dispose();
-    }
-    this.docs.clear();
-    this.bundlers.clear();
-    this.aware.clear();
-    await this.svs.stop();
-    await this.db.close();
   }
 
   /**
    * Start the provider.
    * This will subscribe to updates and load persisted data.
    */
-  private async start() {
-    await this.svs.subscribe({
+  public async start(): Promise<void> {
+    if (this.destroyed) throw new Error('Cannot start a destroyed SVS provider');
+    if (this.started) return;
+    if (!this.startPromise) {
+      this.startPromise = this.startInternal().finally(() => {
+        this.startPromise = null;
+      });
+    }
+    await this.startPromise;
+  }
+
+  private async startInternal(): Promise<void> {
+    if (!this.subscribed) await this.svs.subscribe({
       on_yjs_delta: async (pubs) => {
         try {
           // Persist the updates to database
@@ -166,30 +226,30 @@ export class SvsProvider {
       },
 
       on_mls_kp_ref: async (pub) => {
-          try {
-            if (!this.mlsCallbacksReady) { this.pendingMlsKpRefs.push(...pub); return; }
-            await this.onMlsKpRef(pub);
-          } catch (e) {
-            console.error('MLS kp callback failed', e);
-          }
+        try {
+          if (!this.mlsCallbacksReady) { this.pendingMlsKpRefs.push(...pub); return; }
+          await this.enqueueMlsDispatch(async () => this.onMlsKpRef(pub));
+        } catch (e) {
+          console.error('MLS kp callback failed', e);
+        }
       },
 
       on_mls_welcome_ref: async (pub) => {
-          try {
-            if (!this.mlsCallbacksReady) { this.pendingMlsWelcomeRefs.push(...pub); return; }
-            await this.onMlsWelcomeRef(pub);
-          } catch (e) {
-            console.error('MLS welcome callback failed', e);
-          }
+        try {
+          if (!this.mlsCallbacksReady) { this.pendingMlsWelcomeRefs.push(...pub); return; }
+          await this.enqueueMlsDispatch(async () => this.onMlsWelcomeRef(pub));
+        } catch (e) {
+          console.error('MLS welcome callback failed', e);
+        }
       },
 
       on_mls_commit_ref: async (pub) => {
-          try {
-            if (!this.mlsCallbacksReady) { this.pendingMlsCommitRefs.push(...pub); return; }
-            await this.onMlsCommitRef(pub);
-          } catch (e) {
-            console.error('MLS commit callback failed', e);
-          }
+        try {
+          if (!this.mlsCallbacksReady) { this.pendingMlsCommitRefs.push(...pub); return; }
+          await this.enqueueMlsDispatch(async () => this.onMlsCommitRef(pub));
+        } catch (e) {
+          console.error('MLS commit callback failed', e);
+        }
       },
 
       on_refresh_ping: async (pubs) => {
@@ -201,7 +261,9 @@ export class SvsProvider {
       },
 
     });
+    this.subscribed = true;
     await this.svs.start();
+    this.started = true;
   }
 
   public async stateGet(type: string): Promise<Uint8Array | undefined> {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -36,6 +36,8 @@ export type IWkspStats = {
   mlsJoinAttempts?: number;
   mlsOwnerBootstrapped?: boolean;
   mlsKeys?: IMlsKey[];
+  /** Previous device identity replaced after local MLS state was lost. */
+  mlsRecoveryPreviousDeviceId?: string;
   /** Member selected to help recover an owner device into MLS */
   ownerRecoveryHelper?: string;
   /** Time when this owner device requested member-assisted MLS recovery */

--- a/src/services/workspace-invite.ts
+++ b/src/services/workspace-invite.ts
@@ -15,10 +15,13 @@ import {
 
 const MLS_STORAGE_STATE_KEY = 'mls/storage/v1';
 const MLS_GROUP_ID_STATE_KEY = 'mls/group-id/v1';
+const MLS_PENDING_STORAGE_STATE_KEY = 'mls/pending-storage/v1';
+const MLS_PENDING_KEY_PACKAGE_STATE_KEY = 'mls/pending-key-package/v1';
 const MLS_RESET_SENTINEL = '__mls_reset__';
 const MLS_PREJOIN_SESSION_ID = 'prejoin';
 const MLS_COMMIT_BROADCAST = '__mls_commit_broadcast__';
 const MLS_OWNER_RECOVERY_SESSION_PREFIX = 'owner-recovery:';
+const MLS_DEVICE_RECOVERY_SESSION_PREFIX = 'device-recovery:';
 const OWNER_CONTROL_MAP = 'owner-control';
 const OWNER_MASTER_DEVICE_ID_KEY = 'masterDeviceId';
 const OWNER_DEVICES_MAP = 'owner-devices';
@@ -31,6 +34,8 @@ export class WorkspaceInviteManager {
   private mlsClient: OpenMlsLiteClient | null = null;
   private mlsGroup: OpenMlsLiteGroup | null = null;
   private mlsInitPromise: Promise<void> | null = null;
+  private pendingKeyPackage: Uint8Array | null = null;
+  private restoredPendingMlsClient = false;
   private pendingCommitRefs: MlsRefPub[] = [];
   private pendingOwnerRecoveryKpRefs: MlsRefPub[] = [];
   private onOwnerSessionAdvanced: ((sessionId: string) => Promise<void>) | null = null;
@@ -69,16 +74,26 @@ export class WorkspaceInviteManager {
     const doc = await provider.getDoc('invite');
     const mgr = new WorkspaceInviteManager(api, wsmeta, provider, doc);
 
-    provider.setMlsCallbacks({
-      onMlsKpRef: async (pubs) => mgr.onMlsKpRefs(pubs),
-      onMlsWelcomeRef: async (pubs) => mgr.onMlsWelcomeRefs(pubs),
-      onMlsCommitRef: async (pubs) => mgr.onMlsCommitRefs(pubs),
-    });
+    try {
+      provider.setMlsCallbacks({
+        onMlsKpRef: async (pubs) => mgr.onMlsKpRefs(pubs),
+        onMlsWelcomeRef: async (pubs) => mgr.onMlsWelcomeRefs(pubs),
+        onMlsCommitRef: async (pubs) => mgr.onMlsCommitRefs(pubs),
+      });
 
-    await mgr.initializeOwnerDeviceRole();
-    await mgr.restoreMlsStateOnStartup();
+      await mgr.initializeOwnerDeviceRole();
+      await mgr.restoreMlsStateOnStartup();
+      // Welcome and Commit references may have arrived while local MLS state was
+      // being restored. Process them only after restoration is complete.
+      await provider.activateMlsCallbacks();
 
-    return mgr;
+      return mgr;
+    } catch (e) {
+      // Keep the original initialization error; this manager is not exposed if
+      // its best-effort cleanup also fails.
+      await mgr.destroy().catch(() => {});
+      throw e;
+    }
   }
 
   /**
@@ -116,6 +131,14 @@ export class WorkspaceInviteManager {
     if (!pub.session_id.startsWith(MLS_OWNER_RECOVERY_SESSION_PREFIX)) return null;
     const target = pub.session_id.slice(MLS_OWNER_RECOVERY_SESSION_PREFIX.length).trim();
     return target ? utils.normalizePath(target) : null;
+  }
+
+  private deviceRecoveryPreviousDeviceId(pub: MlsRefPub): string | null {
+    if (!pub.session_id.startsWith(MLS_DEVICE_RECOVERY_SESSION_PREFIX)) return null;
+    const deviceId = pub.session_id.slice(MLS_DEVICE_RECOVERY_SESSION_PREFIX.length).trim();
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(deviceId)
+      ? deviceId
+      : null;
   }
 
   private defaultOwnerDeviceLabel(deviceId: string): string {
@@ -313,11 +336,47 @@ export class WorkspaceInviteManager {
       throw new Error(`Owner device ${targetDeviceId} is not registered`);
     }
     if (this.sharedMasterDeviceId() === targetDeviceId) {
+      if (claimingLocalDevice) {
+        await this.completeMlsRecoveryIfReady();
+      }
       return;
     }
 
     this.ownerControl.set(OWNER_MASTER_DEVICE_ID_KEY, targetDeviceId);
     await this.syncMasterDeviceFlag();
+
+    if (claimingLocalDevice) {
+      try {
+        await this.completeMlsRecoveryIfReady();
+      } catch (err) {
+        // Taking over is complete even if removal of the abandoned leaf must
+        // be retried on a later startup.
+        console.warn('Failed to clean replaced owner MLS device', err);
+      }
+    }
+  }
+
+  /** Remove the abandoned owner leaf once the replacement device is master. */
+  public async completeMlsRecoveryIfReady(): Promise<void> {
+    const previousDeviceId = this.wsmeta.mlsRecoveryPreviousDeviceId?.trim();
+    if (!previousDeviceId || !this.mlsGroup) return;
+
+    if (!this.wsmeta.owner) {
+      this.wsmeta.mlsRecoveryPreviousDeviceId = undefined;
+      await _o.stats.put(this.wsmeta.name, this.wsmeta);
+      return;
+    }
+
+    // A recovered owner stays secondary until the user explicitly makes it
+    // master. Only the master is allowed to remove the old owner leaf.
+    if (!this.isMasterDevice()) return;
+
+    if (previousDeviceId !== this.wsmeta.deviceId && this.ownerDevices.has(previousDeviceId)) {
+      await this.removeOwnerDevice(previousDeviceId);
+    }
+
+    this.wsmeta.mlsRecoveryPreviousDeviceId = undefined;
+    await _o.stats.put(this.wsmeta.name, this.wsmeta);
   }
 
   private assertOwnerCanMergeMls(action: string): void {
@@ -484,6 +543,53 @@ export class WorkspaceInviteManager {
     await this.provider.statePut(MLS_GROUP_ID_STATE_KEY, new Uint8Array());
   }
 
+  private async clearPendingMlsJoinState(): Promise<void> {
+    this.pendingKeyPackage = null;
+    this.restoredPendingMlsClient = false;
+    await this.provider.statePut(MLS_PENDING_STORAGE_STATE_KEY, new Uint8Array());
+    await this.provider.statePut(MLS_PENDING_KEY_PACKAGE_STATE_KEY, new Uint8Array());
+  }
+
+  private async restorePendingMlsJoinState(): Promise<boolean> {
+    const [snapshot, keyPackage] = await Promise.all([
+      this.provider.stateGet(MLS_PENDING_STORAGE_STATE_KEY),
+      this.provider.stateGet(MLS_PENDING_KEY_PACKAGE_STATE_KEY),
+    ]);
+
+    const hasSnapshot = this.isPersistedStatePresent(snapshot);
+    const hasKeyPackage = this.isPersistedStatePresent(keyPackage);
+    if (!hasSnapshot && !hasKeyPackage) return false;
+    if (!hasSnapshot || !hasKeyPackage) {
+      throw new Error('Incomplete pending MLS join state');
+    }
+
+    const client = await this.getMlsClient();
+    client.importStorageSnapshot(snapshot!);
+    const identity = new TextDecoder().decode(client.keyPackageIdentity(keyPackage!));
+    if (identity !== this.currentMlsIdentity()) {
+      throw new Error('Pending MLS key package belongs to another device identity');
+    }
+
+    this.pendingKeyPackage = keyPackage!;
+    this.restoredPendingMlsClient = true;
+    return true;
+  }
+
+  private async getOrCreatePendingKeyPackage(): Promise<Uint8Array> {
+    if (this.pendingKeyPackage) return this.pendingKeyPackage;
+
+    const client = await this.getMlsClient();
+    const keyPackage = client.keyPackage();
+    const snapshot = client.exportStorageSnapshot();
+
+    // Persist the private KeyPackage material before publishing its reference,
+    // so a reload can still consume the corresponding Welcome.
+    await this.provider.statePut(MLS_PENDING_STORAGE_STATE_KEY, snapshot);
+    await this.provider.statePut(MLS_PENDING_KEY_PACKAGE_STATE_KEY, keyPackage);
+    this.pendingKeyPackage = keyPackage;
+    return keyPackage;
+  }
+
   private isPersistedStatePresent(state: Uint8Array | undefined): boolean {
     return !!state && state.byteLength > 0;
   }
@@ -513,10 +619,12 @@ export class WorkspaceInviteManager {
     this.wsmeta.mlsJoinAttempts = undefined;
     this.wsmeta.mlsOwnerBootstrapped = false;
     this.wsmeta.mlsKeys = undefined;
+    this.wsmeta.mlsRecoveryPreviousDeviceId = undefined;
     this.wsmeta.ownerRecoveryHelper = undefined;
     this.wsmeta.ownerRecoveryRequestedAt = undefined;
 
     await this.clearPersistedMlsState();
+    await this.clearPendingMlsJoinState();
     await this.restoreLegacyWorkspaceKey();
     await _o.stats.put(this.wsmeta.name, this.wsmeta);
 
@@ -544,6 +652,7 @@ export class WorkspaceInviteManager {
     this.wsmeta.mlsJoinAttempts = undefined;
     this.wsmeta.mlsOwnerBootstrapped = false;
     this.wsmeta.mlsKeys = undefined;
+    this.wsmeta.mlsRecoveryPreviousDeviceId = undefined;
     this.wsmeta.ownerRecoveryHelper = undefined;
     this.wsmeta.ownerRecoveryRequestedAt = undefined;
     this.wsmeta.dsk = null;
@@ -551,6 +660,7 @@ export class WorkspaceInviteManager {
     this.wsmeta.revoked = true;
 
     await this.clearPersistedMlsState();
+    await this.clearPendingMlsJoinState();
     await _o.stats.put(this.wsmeta.name, this.wsmeta);
     GlobalBus.emit(
       'workspace-revoked',
@@ -578,6 +688,10 @@ export class WorkspaceInviteManager {
     this.mlsGroup?.free();
     this.mlsGroup = client.loadGroup(groupId!);
 
+    return true;
+  }
+
+  private async resumeRestoredMlsState(): Promise<void> {
     await this.rotateWorkspaceMlsKey();
     await this.drainPendingCommitRefs();
     await this.drainPendingOwnerRecoveryKeyPackages();
@@ -588,7 +702,6 @@ export class WorkspaceInviteManager {
       await _o.stats.put(this.wsmeta.name, this.wsmeta);
     }
     this.maybeRegisterLocalOwnerDeviceRecord();
-    return true;
   }
 
   private async drainPendingCommitRefs(): Promise<void> {
@@ -641,20 +754,98 @@ export class WorkspaceInviteManager {
   }
 
   private async restoreMlsStateOnStartup(): Promise<void> {
+    let restored: boolean;
     try {
-      const restored = await this.restoreMlsStateIfAvailable();
-      if (!restored && this.wsmeta.owner && this.isMasterDevice() && this.wsmeta.mlsOwnerBootstrapped) {
-        throw new Error('Owner MLS restore failed: missing persisted state');
-      }
+      restored = await this.restoreMlsStateIfAvailable();
     } catch (e) {
-      if (this.wsmeta.owner && this.isMasterDevice() && this.wsmeta.mlsOwnerBootstrapped) {
-        throw e;
-      }
-      console.warn('MLS restore failed; resetting join request flags', e);
+      await this.prepareLostMlsRecovery(e);
+      return;
+    }
+
+    if (restored) {
+      // Errors after the group has loaded are runtime/protocol failures, not
+      // proof that its persisted private state should be discarded.
+      await this.resumeRestoredMlsState();
+      // Full group state takes precedence; stale pre-join state can be retried
+      // on a later startup if this best-effort cleanup fails.
+      await this.clearPendingMlsJoinState().catch(() => {});
+      return;
+    }
+
+    try {
+      if (await this.restorePendingMlsJoinState()) return;
+    } catch {
+      // Import may have replaced the client's signer or other private state.
+      // Discard it before generating the fresh KeyPackage below.
+      this.mlsClient?.free();
+      this.mlsClient = null;
+      this.pendingKeyPackage = null;
+      this.restoredPendingMlsClient = false;
+      await this.clearPendingMlsJoinState();
       this.wsmeta.mlsJoinRequested = false;
       this.wsmeta.mlsJoinRequestedAt = undefined;
       await _o.stats.put(this.wsmeta.name, this.wsmeta);
     }
+
+    const previouslyJoined =
+      !!this.wsmeta.mlsOwnerBootstrapped ||
+      !!this.wsmeta.mlsKeys?.length ||
+      !!this.wsmeta.mlsRecoveryPreviousDeviceId;
+
+    if (previouslyJoined) {
+      await this.prepareLostMlsRecovery('persisted MLS group state is missing');
+      return;
+    }
+
+    // Old versions did not persist pending KeyPackage state. Allow their
+    // outstanding join to be republished by the normal startup retry.
+    if (this.wsmeta.mlsJoinRequested) {
+      this.wsmeta.mlsJoinRequested = false;
+      this.wsmeta.mlsJoinRequestedAt = undefined;
+      await _o.stats.put(this.wsmeta.name, this.wsmeta);
+    }
+  }
+
+  private async prepareLostMlsRecovery(reason: unknown): Promise<void> {
+    const currentDeviceId = this.wsmeta.deviceId?.trim();
+    if (!currentDeviceId) {
+      throw new Error('Cannot recover lost MLS state without a local device ID');
+    }
+
+    // Preserve the first abandoned identity across interrupted recovery
+    // attempts so a former master can still clean up its original leaf.
+    const previousDeviceId = this.wsmeta.mlsRecoveryPreviousDeviceId?.trim() || currentDeviceId;
+    let replacementDeviceId: string;
+    do {
+      replacementDeviceId = globalThis.crypto.randomUUID();
+    } while (replacementDeviceId === currentDeviceId);
+
+    console.warn(`Recovering from unavailable local MLS state: ${reason}`);
+    this.mlsGroup?.free();
+    this.mlsGroup = null;
+    this.mlsClient?.free();
+    this.mlsClient = null;
+    this.pendingCommitRefs = [];
+    this.pendingOwnerRecoveryKpRefs = [];
+
+    // The previous MLS leaf cannot be resumed without its private state. A new
+    // device identity prevents the replacement leaf from colliding with it.
+    this.wsmeta.deviceId = replacementDeviceId;
+    this.wsmeta.isMasterDevice = false;
+    this.wsmeta.mlsRecoveryPreviousDeviceId = previousDeviceId;
+    this.wsmeta.mlsJoinRequested = false;
+    this.wsmeta.mlsJoinRequestedAt = undefined;
+    this.wsmeta.mlsJoinAttempts = undefined;
+    this.wsmeta.mlsOwnerBootstrapped = false;
+    this.wsmeta.ownerRecoveryHelper = undefined;
+    this.wsmeta.ownerRecoveryRequestedAt = undefined;
+
+    // Keep cached MLS transport keys: they can still decrypt older content,
+    // although they cannot replace the missing MLS state machine.
+    await this.clearPersistedMlsState();
+    await this.clearPendingMlsJoinState();
+    await this.restoreLegacyWorkspaceKey();
+    await _o.stats.put(this.wsmeta.name, this.wsmeta);
   }
 
   /**
@@ -679,7 +870,21 @@ export class WorkspaceInviteManager {
     const client = await this.getMlsClient();
     this.mlsGroup?.free();
     this.mlsGroup = client.joinFromWelcome(welcome);
+
+    if (this.restoredPendingMlsClient) {
+      // Client construction creates a temporary signer before the persisted
+      // KeyPackage storage is imported. Reloading the joined group reconstructs
+      // the signer that actually belongs to the accepted KeyPackage.
+      await this.persistMlsState();
+      const groupId = this.mlsGroup.groupIdBytes();
+      this.mlsGroup.free();
+      this.mlsGroup = client.loadGroup(groupId);
+    }
+
     await this.rotateWorkspaceMlsKey(sessionId);
+    // Full group state is already persisted, so stale pre-join state is safe
+    // to clean on the next startup if this best-effort write fails.
+    await this.clearPendingMlsJoinState().catch(() => {});
     await this.drainPendingCommitRefs();
     await this.drainPendingOwnerRecoveryKeyPackages();
     this.reconcileOwnerDeviceRegistryFromMls();
@@ -688,6 +893,11 @@ export class WorkspaceInviteManager {
       this.wsmeta.ownerRecoveryHelper = undefined;
       await this.syncMasterDeviceFlag();
       await _o.stats.put(this.wsmeta.name, this.wsmeta);
+    }
+    try {
+      await this.completeMlsRecoveryIfReady();
+    } catch (err) {
+      console.warn('Failed to finish local MLS recovery cleanup', err);
     }
   }
 
@@ -732,7 +942,23 @@ export class WorkspaceInviteManager {
 
       await this.provider.svs.pub_mls_commit_ref(MLS_COMMIT_BROADCAST, commitBlob, sessionId);
       await this.provider.svs.pub_mls_welcome_ref(inviteeIdentity, welcomeBlob, sessionId);
-      await this.notifyOwnerSessionAdvanced(sessionId);
+
+      const previousDeviceId = this.deviceRecoveryPreviousDeviceId(pub);
+      let removalSessionId: string | null = null;
+      if (previousDeviceId) {
+        try {
+          removalSessionId = await this.removeReplacedMemberDevice(
+            inviteeIdentity,
+            previousDeviceId,
+            pub.publisher,
+          );
+        } catch (e) {
+          // The replacement is already admitted; stale-leaf cleanup must not
+          // suppress its Welcome or the Coredump for the add commit.
+          console.warn('Failed to remove replaced MLS member device', e);
+        }
+      }
+      await this.notifyOwnerSessionAdvanced(removalSessionId ?? sessionId);
     }
   }
 
@@ -819,8 +1045,7 @@ export class WorkspaceInviteManager {
   }
 
   public async publishKeyPackageRef(sessionId = MLS_PREJOIN_SESSION_ID): Promise<void> {
-    const client = await this.getMlsClient();
-    const kp = client.keyPackage();
+    const kp = await this.getOrCreatePendingKeyPackage();
     const identity = this.currentMlsIdentity();
     const inviteeKey = utils.escapeUrlName(identity);
     const blob = await this.provider.publishBlob(`mls-kp-${inviteeKey}`, kp);
@@ -833,7 +1058,13 @@ export class WorkspaceInviteManager {
     }
 
     try {
-      await this.publishKeyPackageRef();
+      const previousDeviceId = !this.wsmeta.owner
+        ? this.wsmeta.mlsRecoveryPreviousDeviceId?.trim()
+        : undefined;
+      const requestSessionId = previousDeviceId
+        ? `${MLS_DEVICE_RECOVERY_SESSION_PREFIX}${previousDeviceId}`
+        : MLS_PREJOIN_SESSION_ID;
+      await this.publishKeyPackageRef(requestSessionId);
       this.wsmeta.mlsJoinRequested = true;
       this.wsmeta.mlsJoinRequestedAt = Date.now();
       this.wsmeta.mlsJoinAttempts = (this.wsmeta.mlsJoinAttempts ?? 0) + 1;
@@ -927,6 +1158,42 @@ export class WorkspaceInviteManager {
       welcome,
       sessionId,
     };
+  }
+
+  private async removeReplacedMemberDevice(
+    replacementIdentity: string,
+    previousDeviceId: string,
+    publisher: string,
+  ): Promise<string | null> {
+    const replacement = parseMlsIdentity(replacementIdentity);
+    if (
+      replacement.accountId === this.workspaceOwnerAccountId() ||
+      replacement.deviceId === previousDeviceId ||
+      utils.normalizePath(publisher) !== utils.normalizePath(replacement.accountId)
+    ) {
+      return null;
+    }
+
+    const previousIdentity = encodeMlsIdentity(replacement.accountId, previousDeviceId);
+    const group = await this.getMlsGroup();
+    const indexes = group.memberIndexesByIdentity(new TextEncoder().encode(previousIdentity));
+    if (!indexes.length) return null;
+    if (indexes.includes(group.myIndex())) {
+      throw new Error('Refusing member recovery request that would remove the master device');
+    }
+
+    const { commit } = group.removeMembers(indexes);
+    group.mergePendingCommit();
+
+    const sessionId = this.currentMlsSessionId();
+    await this.rotateWorkspaceMlsKey(sessionId);
+
+    const blob = await this.provider.publishBlob(
+      `mls-commit-replace-${utils.escapeUrlName(previousIdentity)}`,
+      commit,
+    );
+    await this.provider.svs.pub_mls_commit_ref(previousIdentity, blob, sessionId);
+    return sessionId;
   }
 
   private async addOwnerRecoveryFromKeyPackage(

--- a/src/services/workspace.ts
+++ b/src/services/workspace.ts
@@ -78,6 +78,10 @@ export class Workspace {
 
     // Set up workspace API and client
     let api: WorkspaceAPI | null = null;
+    let provider: SvsProvider | null = null;
+    let chat: WorkspaceChat | null = null;
+    let proj: WorkspaceProjManager | null = null;
+    let invite: WorkspaceInviteManager | null = null;
     try {
 
       api = await ndn.api.get_workspace(
@@ -117,17 +121,40 @@ export class Workspace {
         }
       }
 
-      // Create general SVS group
-      const provider = await SvsProvider.create(api, 'root');
+      // Build the root provider without starting network delivery. MLS state
+      // and callbacks must be ready before Welcome or Commit refs can arrive.
+      provider = await SvsProvider.createPaused(api, 'root');
 
       // Create general modules
-      const chat = await WorkspaceChat.create(api, provider);
-      const proj = await WorkspaceProjManager.create(api, provider);
-      const invite = await WorkspaceInviteManager.create(api, metadata, provider);
+      chat = await WorkspaceChat.create(api, provider);
+      proj = await WorkspaceProjManager.create(api, provider);
+      invite = await WorkspaceInviteManager.create(api, metadata, provider);
+      const inviteManager = invite;
+
+      const workspace = new Workspace(metadata, api, provider, chat, proj, inviteManager);
+      inviteManager.setOnOwnerSessionAdvanced(async () => {
+        await workspace.republishEncryptedState();
+      });
+      workspace.registerRefreshHandlers();
+      await api.set_on_refresh_req(workspace.currentDeviceIdentity(), async () => {
+        await workspace.republishEncryptedState();
+      });
+      if (metadata.owner) {
+        await api.set_on_mls_rst_req(workspace.currentDeviceIdentity(), async () => {
+          if (!inviteManager.isMasterDevice()) {
+            throw new Error('Only the master owner device can reset MLS state');
+          }
+          await inviteManager.resetGroupMlsState();
+        });
+      }
+
+      // All consumers are now ready, so incoming root SVS updates can be
+      // processed immediately instead of being buffered during startup.
+      await provider.start();
 
       const shouldRequestMls =
-        !(metadata.owner && metadata.isMasterDevice) &&
-        !(metadata.mlsKeys?.length) &&
+        !inviteManager.hasMlsGroup() &&
+        !(metadata.owner && inviteManager.isMasterDevice()) &&
         (
           !metadata.mlsJoinRequested ||
           !metadata.mlsJoinRequestedAt ||
@@ -136,7 +163,7 @@ export class Workspace {
 
       if (shouldRequestMls) {
         try {
-          await invite.requestMlsJoin();
+          await inviteManager.requestMlsJoin();
         } catch (e) {
           // keep workspace usable; retry next startup
           console.warn('Failed to publish MLS key package ref', e);
@@ -146,28 +173,28 @@ export class Workspace {
       }
 
 
-      const workspace = new Workspace(metadata, api, provider, chat, proj, invite);
-      invite.setOnOwnerSessionAdvanced(async () => {
-        await workspace.republishEncryptedState();
-      });
-      workspace.registerRefreshHandlers();
-      await api.set_on_refresh_req(workspace.currentDeviceIdentity(), async () => {
-        await workspace.republishEncryptedState();
-      });
-      if (metadata.owner) {
-        await api.set_on_mls_rst_req(workspace.currentDeviceIdentity(), async () => {
-          if (!invite.isMasterDevice()) {
-            throw new Error('Only the master owner device can reset MLS state');
-          }
-          await invite.resetGroupMlsState();
-        });
+      try {
+        await inviteManager.completeMlsRecoveryIfReady();
+      } catch (e) {
+        // A stale owner leaf can be removed later; it should not prevent the
+        // recovered workspace from opening.
+        console.warn('Failed to finish MLS recovery cleanup', e);
       }
       workspace.scheduleAutoOwnerRecovery();
 
       return workspace;
     } catch (e) {
-      // Clean up if we failed to start
-      api?.stop();
+      // Startup can fail after SVS has attached its route. Tear down every
+      // completed layer before allowing setup() to retry the same workspace.
+      const cleanupErrors: unknown[] = [];
+      try { await provider?.destroy(); } catch (cleanupError) { cleanupErrors.push(cleanupError); }
+      try { await invite?.destroy(); } catch (cleanupError) { cleanupErrors.push(cleanupError); }
+      try { await proj?.destroy(); } catch (cleanupError) { cleanupErrors.push(cleanupError); }
+      try { await chat?.destroy(); } catch (cleanupError) { cleanupErrors.push(cleanupError); }
+      try { await api?.stop(); } catch (cleanupError) { cleanupErrors.push(cleanupError); }
+      if (cleanupErrors.length) {
+        console.warn('Workspace startup cleanup was incomplete', cleanupErrors);
+      }
       throw e;
     }
   }
@@ -177,8 +204,6 @@ export class Workspace {
    * This will stop the SVS instance and disconnect from the testbed.
    */
   public async destroy() {
-    await this.proj.destroy();
-    await this.chat.destroy();
     for (const off of this.refreshUnsubs) {
       off();
     }
@@ -191,8 +216,10 @@ export class Workspace {
     }
 
     await this.provider?.destroy();
-    await this.api?.stop();
+    await this.proj.destroy();
+    await this.chat.destroy();
     await this.invite.destroy();
+    await this.api?.stop();
 
     if (globalThis.ActiveWorkspace === this) {
       globalThis.ActiveWorkspace = null;
@@ -738,7 +765,7 @@ export class Workspace {
     } catch (e) {
       throw new Error(`No DSK, try again later when others are online: ${e}`);
     } finally {
-      rootSvs?.stop();
+      await rootSvs?.stop();
     }
   }
 


### PR DESCRIPTION
… MLS state machine on start up

- For the issue where snapshot data may be encrypted with a newer encryption key:
  - Snapshot data now handled in two passes: first pass processes MLS commits, second pass processes data
  - Added retry queue in case another snapshot contains commits for new data

- For devices missing MLS state machines on startup:
  - Startup now checks the actual MLS group instead of treating cached keys as a working state machine
  - Generates a new deviceID
  - Rejoins the existing MLS group
  - Ordinary members have their abandoned MLS leaf removed by the master
  - Recovered owners remain secondary until explicitly made master; takeover then removes the abandoned owner leaf